### PR TITLE
feat: Enable multi-platform builds for board server

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,8 +111,6 @@ jobs:
           provenance: true
           platforms: linux/amd64,linux/arm64,darwin/arm64
           tags: >
-            ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ github.sha }},
-            ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ needs.setup.outputs.short_hash }},
             ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ needs.setup.outputs.package_version }},
             ${{ needs.setup.outputs.board_server_sqlite_image_path }}:latest
           build-args: |
@@ -170,8 +168,6 @@ jobs:
           provenance: true
           platforms: linux/amd64,linux/arm64,darwin/arm64
           tags: >
-            ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ github.sha }},
-            ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ needs.setup.outputs.short_hash }},
             ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ needs.setup.outputs.package_version }},
             ${{ needs.setup.outputs.board_server_firestore_image_path }}:latest
           build-args: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,6 +109,7 @@ jobs:
           cache-to: type=gha,mode=max,ref=${{ needs.setup.outputs.board_server_sqlite_image_name }}
           push: true
           provenance: true
+          platforms: linux/amd64,linux/arm64,darwin/arm64
           tags: >
             ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ github.sha }},
             ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ needs.setup.outputs.short_hash }},
@@ -167,6 +168,7 @@ jobs:
             type=registry,mode=max,ref=${{ needs.setup.outputs.board_server_firestore_image_path }}
           push: true
           provenance: true
+          platforms: linux/amd64,linux/arm64,darwin/arm64
           tags: >
             ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ github.sha }},
             ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ needs.setup.outputs.short_hash }},


### PR DESCRIPTION
- Enable linux/arm64, linux/amd64 and darwin/arm64 builds to cover more bases
- Remove all tags other than `latest` and semver tags, as there seems to be something wrong with the sha tagged images.